### PR TITLE
Consensus separation - common components

### DIFF
--- a/core/constants.go
+++ b/core/constants.go
@@ -230,3 +230,19 @@ const SCDeployIdentifier = "SCDeploy"
 
 // SCUpgradeIdentifier is the identifier for a smart contract upgrade
 const SCUpgradeIdentifier = "SCUpgrade"
+
+// BlockHeaderState specifies which is the state of the block header received
+type BlockHeaderState int
+
+const (
+	// BHReceived defines ID of a received block header
+	BHReceived BlockHeaderState = iota
+	// BHReceivedTooLate defines ID of a late received block header
+	BHReceivedTooLate
+	// BHProcessed defines ID of a processed block header
+	BHProcessed
+	// BHProposed defines ID of a proposed block header
+	BHProposed
+	// BHNotarized defines ID of a notarized block header
+	BHNotarized
+)

--- a/core/constants.go
+++ b/core/constants.go
@@ -246,3 +246,32 @@ const (
 	// BHNotarized defines ID of a notarized block header
 	BHNotarized
 )
+
+const (
+	// StorerOrder defines the order of storers to be notified of a start of epoch event
+	StorerOrder = iota
+	// NodesCoordinatorOrder defines the order in which NodesCoordinator is notified of a start of epoch event
+	NodesCoordinatorOrder
+	// ConsensusOrder defines the order in which Consensus is notified of a start of epoch event
+	ConsensusOrder
+	// NetworkShardingOrder defines the order in which the network sharding subsystem is notified of a start of epoch event
+	NetworkShardingOrder
+	// IndexerOrder defines the order in which indexer is notified of a start of epoch event
+	IndexerOrder
+	// NetStatisticsOrder defines the order in which netStatistic component is notified of a start of epoch event
+	NetStatisticsOrder
+	// OldDatabaseCleanOrder defines the order in which oldDatabaseCleaner component is notified of a start of epoch event
+	OldDatabaseCleanOrder
+)
+
+// NodeState specifies what type of state a node could have
+type NodeState int
+
+const (
+	// NsSynchronized defines ID of a state of synchronized
+	NsSynchronized NodeState = iota
+	// NsNotSynchronized defines ID of a state of not synchronized
+	NsNotSynchronized
+	// NsNotCalculated defines ID of a state which is not calculated
+	NsNotCalculated
+)

--- a/core/context.go
+++ b/core/context.go
@@ -1,0 +1,17 @@
+package core
+
+import "context"
+
+// IsContextDone will return true if the provided context signals it is done
+func IsContextDone(ctx context.Context) bool {
+	if ctx == nil {
+		return true
+	}
+
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -1,0 +1,46 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// nolint
+func TestIsContextDone(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid context tests", func(t *testing.T) {
+		numTests := 10
+		ctx, cancel := context.WithCancel(context.Background())
+		for i := 0; i < numTests; i++ {
+			assert.False(t, IsContextDone(ctx))
+		}
+		cancel()
+		for i := 0; i < numTests; i++ {
+			assert.True(t, IsContextDone(ctx))
+		}
+	})
+	t.Run("nil context", func(t *testing.T) {
+		assert.True(t, IsContextDone(nil))
+	})
+}
+
+func BenchmarkIsContextDone_WhenDone(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for i := 0; i < b.N; i++ {
+		_ = IsContextDone(ctx)
+	}
+}
+
+func BenchmarkIsContextDone_WhenNotDone(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for i := 0; i < b.N; i++ {
+		_ = IsContextDone(ctx)
+	}
+}

--- a/core/interface.go
+++ b/core/interface.go
@@ -2,6 +2,9 @@ package core
 
 import (
 	"time"
+
+	"github.com/ElrondNetwork/elrond-go-core/data"
+	core "github.com/libp2p/go-libp2p-core"
 )
 
 // AppStatusHandler interface will handle different implementations of monitoring tools, such as term-ui or status metrics
@@ -125,4 +128,51 @@ type Logger interface {
 	Error(message string, args ...interface{})
 	LogIfError(err error, args ...interface{})
 	IsInterfaceNil() bool
+}
+
+// MessageP2P defines what a p2p message can do (should return)
+type MessageP2P interface {
+	From() []byte
+	Data() []byte
+	Payload() []byte
+	SeqNo() []byte
+	Topic() string
+	Signature() []byte
+	Key() []byte
+	Peer() core.PeerID
+	Timestamp() int64
+	IsInterfaceNil() bool
+}
+
+// InterceptedDebugger defines an interface for debugging the intercepted data
+type InterceptedDebugger interface {
+	LogReceivedHashes(topic string, hashes [][]byte)
+	LogProcessedHashes(topic string, hashes [][]byte, err error)
+	IsInterfaceNil() bool
+}
+
+// Interceptor defines what a data interceptor should do
+// It should also adhere to the p2p.MessageProcessor interface so it can wire to a p2p.Messenger
+type Interceptor interface {
+	ProcessReceivedMessage(message MessageP2P, fromConnectedPeer core.PeerID) error
+	SetInterceptedDebugHandler(handler InterceptedDebugger) error
+	RegisterHandler(handler func(topic string, hash []byte, data interface{}))
+	Close() error
+	IsInterfaceNil() bool
+}
+
+// Validator defines a node that can be allocated to a shard for participation in a consensus group as validator
+// or block proposer
+type Validator interface {
+	PubKey() []byte
+	Chances() uint32
+	Index() uint32
+	Size() int
+}
+
+// EpochStartActionHandler defines the action taken on epoch start event
+type EpochStartActionHandler interface {
+	EpochStartAction(hdr data.HeaderHandler)
+	EpochStartPrepare(metaHdr data.HeaderHandler, body data.BodyHandler)
+	NotifyOrder() uint32
 }

--- a/core/interface.go
+++ b/core/interface.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/ElrondNetwork/elrond-go-core/data"
-	core "github.com/libp2p/go-libp2p-core"
 )
 
 // AppStatusHandler interface will handle different implementations of monitoring tools, such as term-ui or status metrics
@@ -139,7 +138,7 @@ type MessageP2P interface {
 	Topic() string
 	Signature() []byte
 	Key() []byte
-	Peer() core.PeerID
+	Peer() PeerID
 	Timestamp() int64
 	IsInterfaceNil() bool
 }
@@ -154,7 +153,7 @@ type InterceptedDebugger interface {
 // Interceptor defines what a data interceptor should do
 // It should also adhere to the p2p.MessageProcessor interface so it can wire to a p2p.Messenger
 type Interceptor interface {
-	ProcessReceivedMessage(message MessageP2P, fromConnectedPeer core.PeerID) error
+	ProcessReceivedMessage(message MessageP2P, fromConnectedPeer PeerID) error
 	SetInterceptedDebugHandler(handler InterceptedDebugger) error
 	RegisterHandler(handler func(topic string, hash []byte, data interface{}))
 	Close() error

--- a/core/optionals.go
+++ b/core/optionals.go
@@ -1,0 +1,13 @@
+package core
+
+// OptionalUint32 holds an optional uint32 value
+type OptionalUint32 struct {
+	Value    uint32
+	HasValue bool
+}
+
+// OptionalUint64 holds an optional uint64 value
+type OptionalUint64 struct {
+	Value    uint64
+	HasValue bool
+}

--- a/data/api/options.go
+++ b/data/api/options.go
@@ -4,6 +4,8 @@ package api
 type AccountQueryOptions struct {
 	OnFinalBlock   bool
 	OnStartOfEpoch uint32
+	OnBlockNonce   uint64
+	OnBlockHash    string
 }
 
 // BlockQueryOptions holds options for block queries

--- a/data/api/options.go
+++ b/data/api/options.go
@@ -3,8 +3,8 @@ package api
 // AccountQueryOptions holds options for account queries
 type AccountQueryOptions struct {
 	OnFinalBlock   bool
-	OnStartOfEpoch uint32
-	BlockNonce     uint64
+	OnStartOfEpoch *uint32
+	BlockNonce     *uint64
 	BlockHash      string
 	BlockRootHash  string
 }

--- a/data/api/options.go
+++ b/data/api/options.go
@@ -1,10 +1,12 @@
 package api
 
+import "github.com/ElrondNetwork/elrond-go-core/core"
+
 // AccountQueryOptions holds options for account queries
 type AccountQueryOptions struct {
 	OnFinalBlock   bool
-	OnStartOfEpoch *uint32
-	BlockNonce     *uint64
+	OnStartOfEpoch core.OptionalUint32
+	BlockNonce     core.OptionalUint64
 	BlockHash      string
 	BlockRootHash  string
 }

--- a/data/api/options.go
+++ b/data/api/options.go
@@ -7,8 +7,8 @@ type AccountQueryOptions struct {
 	OnFinalBlock   bool
 	OnStartOfEpoch core.OptionalUint32
 	BlockNonce     core.OptionalUint64
-	BlockHash      string
-	BlockRootHash  string
+	BlockHash      []byte
+	BlockRootHash  []byte
 }
 
 // BlockQueryOptions holds options for block queries

--- a/data/api/options.go
+++ b/data/api/options.go
@@ -9,6 +9,7 @@ type AccountQueryOptions struct {
 	BlockNonce     core.OptionalUint64
 	BlockHash      []byte
 	BlockRootHash  []byte
+	HintEpoch      core.OptionalUint32
 }
 
 // BlockQueryOptions holds options for block queries

--- a/data/api/options.go
+++ b/data/api/options.go
@@ -4,8 +4,9 @@ package api
 type AccountQueryOptions struct {
 	OnFinalBlock   bool
 	OnStartOfEpoch uint32
-	OnBlockNonce   uint64
-	OnBlockHash    string
+	BlockNonce     uint64
+	BlockHash      string
+	BlockRootHash  string
 }
 
 // BlockQueryOptions holds options for block queries


### PR DESCRIPTION
Moved several interfaces and constants from elrond-go to core:
- moved IsContextDone to core
- constants for block processing state and node state
- interfaces for p2p message, validator, epoch start action handler