### PR TITLE
FIX: Add LogData back

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -1,0 +1,7 @@
+package data
+
+// LogData holds the data needed for indexing logs and events
+type LogData struct {
+	LogHandler
+	TxHash string
+}


### PR DESCRIPTION
Add previously removed `LogData` structs which is being used in `mx-chain-go`