### PR TITLE
remove 'omitempty' for the guarded api field

### DIFF
--- a/data/api/guardianData.go
+++ b/data/api/guardianData.go
@@ -11,5 +11,5 @@ type Guardian struct {
 type GuardianData struct {
 	ActiveGuardian  *Guardian `json:"activeGuardian,omitempty"`
 	PendingGuardian *Guardian `json:"pendingGuardian,omitempty"`
-	Guarded         bool      `json:"guarded,omitempty"`
+	Guarded         bool      `json:"guarded"`
 }


### PR DESCRIPTION
Remove `omitempty` json property of the GuardianData's `guarded` field so it's more visible if an account isn't guarded