### PR TITLE
 GetMiniBlockHeadersWithDst with finalized executed mbs

### DIFF
--- a/data/block/block.go
+++ b/data/block/block.go
@@ -207,7 +207,7 @@ func (h *Header) SetShardID(shId uint32) error {
 	return nil
 }
 
-// GetMiniBlockHeadersWithDst as a map of hashes and sender IDs
+// GetMiniBlockHeadersWithDst returns a map of hashes and sender IDs
 func (h *Header) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32 {
 	if h == nil {
 		return nil
@@ -220,6 +220,15 @@ func (h *Header) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32 {
 		}
 	}
 	return hashDst
+}
+
+// GetProposedMiniBlockHeadersWithDst returns empty map, as this method just implements the interface needed for supernova
+func (h *Header) GetProposedMiniBlockHeadersWithDst(_ uint32) map[string]uint32 {
+	if h == nil {
+		return nil
+	}
+
+	return make(map[string]uint32)
 }
 
 // GetOrderedCrossMiniblocksWithDst gets all cross miniblocks with the given destination shard ID, ordered in a

--- a/data/block/block.go
+++ b/data/block/block.go
@@ -214,20 +214,13 @@ func (h *Header) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32 {
 	}
 
 	hashDst := make(map[string]uint32)
-	for _, val := range h.MiniBlockHeaders {
-		if val.ReceiverShardID == destId && val.SenderShardID != destId {
-			hashDst[string(val.Hash)] = val.SenderShardID
-		}
-	}
+	addShardMBHeadersMBToDestMap(h.MiniBlockHeaders, hashDst, destId)
+
 	return hashDst
 }
 
 // GetProposedMiniBlockHeadersWithDst returns empty map, as this method just implements the interface needed for supernova
 func (h *Header) GetProposedMiniBlockHeadersWithDst(_ uint32) map[string]uint32 {
-	if h == nil {
-		return nil
-	}
-
 	return make(map[string]uint32)
 }
 

--- a/data/block/blockV2.go
+++ b/data/block/blockV2.go
@@ -362,10 +362,6 @@ func (hv2 *HeaderV2) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32
 
 // GetProposedMiniBlockHeadersWithDst returns empty map, as this method just implements the interface needed for supernova
 func (hv2 *HeaderV2) GetProposedMiniBlockHeadersWithDst(_ uint32) map[string]uint32 {
-	if hv2 == nil {
-		return nil
-	}
-
 	return make(map[string]uint32)
 }
 

--- a/data/block/blockV2.go
+++ b/data/block/blockV2.go
@@ -351,13 +351,22 @@ func (hv2 *HeaderV2) SetShardID(shId uint32) error {
 	return hv2.Header.SetShardID(shId)
 }
 
-// GetMiniBlockHeadersWithDst as a map of hashes and sender IDs
+// GetMiniBlockHeadersWithDst returns a map of hashes and sender IDs
 func (hv2 *HeaderV2) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32 {
 	if hv2 == nil {
 		return nil
 	}
 
 	return hv2.Header.GetMiniBlockHeadersWithDst(destId)
+}
+
+// GetProposedMiniBlockHeadersWithDst returns empty map, as this method just implements the interface needed for supernova
+func (hv2 *HeaderV2) GetProposedMiniBlockHeadersWithDst(_ uint32) map[string]uint32 {
+	if hv2 == nil {
+		return nil
+	}
+
+	return make(map[string]uint32)
 }
 
 // GetOrderedCrossMiniblocksWithDst gets all cross miniblocks with the given destination shard ID, ordered in a

--- a/data/block/blockV2_test.go
+++ b/data/block/blockV2_test.go
@@ -807,6 +807,22 @@ func TestHeaderV2_GetMiniBlockHeadersWithDstShouldWork(t *testing.T) {
 	require.Equal(t, uint32(0), hashesWithDest2[string(hash2S0R2)])
 }
 
+func TestHeaderV2_GetProposedMiniBlockHeadersWithDst(t *testing.T) {
+	t.Parallel()
+
+	hdr := &block.HeaderV2{Header: &block.Header{}}
+	require.Empty(t, hdr.GetProposedMiniBlockHeadersWithDst(0))
+
+	hdr.Header.MiniBlockHeaders = []block.MiniBlockHeader{
+		{
+			SenderShardID:   0,
+			ReceiverShardID: 0,
+			Hash:            []byte("hash"),
+		},
+	}
+	require.Empty(t, hdr.GetProposedMiniBlockHeadersWithDst(0))
+}
+
 func TestHeaderV2_GetOrderedCrossMiniblocksWithDstShouldWork(t *testing.T) {
 	t.Parallel()
 

--- a/data/block/blockV3.go
+++ b/data/block/blockV3.go
@@ -43,11 +43,14 @@ func (hv3 *HeaderV3) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32
 	}
 
 	hashDst := make(map[string]uint32)
-	for _, val := range hv3.MiniBlockHeaders {
-		if val.ReceiverShardID == destId && val.SenderShardID != destId {
-			hashDst[string(val.Hash)] = val.SenderShardID
+	for _, execResults := range hv3.ExecutionResults {
+		for _, mbHeader := range execResults.MiniBlockHeaders {
+			if mbHeader.ReceiverShardID == destId && mbHeader.SenderShardID != destId {
+				hashDst[string(mbHeader.Hash)] = mbHeader.SenderShardID
+			}
 		}
 	}
+
 	return hashDst
 }
 

--- a/data/block/blockV3.go
+++ b/data/block/blockV3.go
@@ -36,7 +36,7 @@ func (hv3 *HeaderV3) GetTimeStamp() uint64 {
 	return hv3.TimestampMs
 }
 
-// GetMiniBlockHeadersWithDst as a map of hashes and sender IDs
+// GetMiniBlockHeadersWithDst returns a map of hashes and sender IDs
 func (hv3 *HeaderV3) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32 {
 	if hv3 == nil {
 		return nil
@@ -44,12 +44,28 @@ func (hv3 *HeaderV3) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32
 
 	hashDst := make(map[string]uint32)
 	for _, execResults := range hv3.ExecutionResults {
-		for _, mbHeader := range execResults.MiniBlockHeaders {
-			if mbHeader.ReceiverShardID == destId && mbHeader.SenderShardID != destId {
-				hashDst[string(mbHeader.Hash)] = mbHeader.SenderShardID
-			}
+		addShardMBHeadersMBToDestMap(execResults.MiniBlockHeaders, hashDst, destId)
+	}
+
+	return hashDst
+}
+
+func addShardMBHeadersMBToDestMap(miniBlockHeaders []MiniBlockHeader, hashDst map[string]uint32, destId uint32) {
+	for _, mbHeader := range miniBlockHeaders {
+		if mbHeader.ReceiverShardID == destId && mbHeader.SenderShardID != destId {
+			hashDst[string(mbHeader.Hash)] = mbHeader.SenderShardID
 		}
 	}
+}
+
+// GetProposedMiniBlockHeadersWithDst returns a map of hashes and sender IDs for proposed mini blocks
+func (hv3 *HeaderV3) GetProposedMiniBlockHeadersWithDst(destId uint32) map[string]uint32 {
+	if hv3 == nil {
+		return nil
+	}
+
+	hashDst := make(map[string]uint32)
+	addShardMBHeadersMBToDestMap(hv3.MiniBlockHeaders, hashDst, destId)
 
 	return hashDst
 }

--- a/data/block/blockV3_test.go
+++ b/data/block/blockV3_test.go
@@ -60,11 +60,27 @@ func TestHeaderV3_GetMiniBlockHeadersWithDst(t *testing.T) {
 	t.Run("no mini blocks with dest", func(t *testing.T) {
 		t.Parallel()
 		hv3 := &block.HeaderV3{
-			MiniBlockHeaders: []block.MiniBlockHeader{
-				{ReceiverShardID: 1, SenderShardID: 0, Hash: []byte("hash1")},
+			ExecutionResults: []*block.ExecutionResult{
+				{
+					MiniBlockHeaders: []block.MiniBlockHeader{
+						{ReceiverShardID: 1, SenderShardID: 0, Hash: []byte("hash1")},
+					},
+				},
 			},
 		}
 		result := hv3.GetMiniBlockHeadersWithDst(2)
+		require.Empty(t, result)
+	})
+
+	t.Run("no mini blocks finalized with destination", func(t *testing.T) {
+		t.Parallel()
+		hash1 := []byte("hash1")
+		hv3 := &block.HeaderV3{
+			MiniBlockHeaders: []block.MiniBlockHeader{
+				{ReceiverShardID: 1, SenderShardID: 0, Hash: hash1},
+			},
+		}
+		result := hv3.GetMiniBlockHeadersWithDst(1)
 		require.Empty(t, result)
 	})
 
@@ -72,15 +88,26 @@ func TestHeaderV3_GetMiniBlockHeadersWithDst(t *testing.T) {
 		t.Parallel()
 		hash1 := []byte("hash1")
 		hash2 := []byte("hash2")
+		hash3 := []byte("hash3")
 		hv3 := &block.HeaderV3{
-			MiniBlockHeaders: []block.MiniBlockHeader{
-				{ReceiverShardID: 1, SenderShardID: 0, Hash: hash1},
-				{ReceiverShardID: 1, SenderShardID: 2, Hash: hash2},
+			ExecutionResults: []*block.ExecutionResult{
+				{
+					MiniBlockHeaders: []block.MiniBlockHeader{
+						{ReceiverShardID: 1, SenderShardID: 0, Hash: hash1},
+						{ReceiverShardID: 1, SenderShardID: 2, Hash: hash2},
+					},
+				},
+				{
+					MiniBlockHeaders: []block.MiniBlockHeader{
+						{ReceiverShardID: 1, SenderShardID: 2, Hash: hash3},
+					},
+				},
 			},
 		}
 		expected := map[string]uint32{
 			string(hash1): 0,
 			string(hash2): 2,
+			string(hash3): 2,
 		}
 		result := hv3.GetMiniBlockHeadersWithDst(1)
 		require.Equal(t, expected, result)

--- a/data/block/blockV3_test.go
+++ b/data/block/blockV3_test.go
@@ -114,6 +114,49 @@ func TestHeaderV3_GetMiniBlockHeadersWithDst(t *testing.T) {
 	})
 }
 
+func TestHeaderV3_GetProposedMiniBlockHeadersWithDst(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil receiver", func(t *testing.T) {
+		t.Parallel()
+		var hv3 *block.HeaderV3
+		require.Nil(t, hv3.GetProposedMiniBlockHeadersWithDst(0))
+	})
+
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		destShardID := uint32(1)
+		hash1 := []byte("hash1")
+		hash2 := []byte("hash2")
+		hash3 := []byte("hash3")
+		hv3 := &block.HeaderV3{
+			MiniBlockHeaders: []block.MiniBlockHeader{
+				{ReceiverShardID: destShardID, SenderShardID: 0, Hash: hash1},
+				{ReceiverShardID: destShardID, SenderShardID: 2, Hash: hash2},
+				{ReceiverShardID: 2, SenderShardID: 2, Hash: hash3},
+			},
+			// should not include execution results
+			ExecutionResults: []*block.ExecutionResult{
+				{
+					MiniBlockHeaders: []block.MiniBlockHeader{
+						{
+							ReceiverShardID: destShardID, SenderShardID: 0, Hash: []byte("hash4"),
+						},
+					},
+				},
+			},
+		}
+
+		expected := map[string]uint32{
+			string(hash1): 0,
+			string(hash2): 2,
+		}
+		result := hv3.GetProposedMiniBlockHeadersWithDst(destShardID)
+		require.Equal(t, expected, result)
+	})
+}
+
 func TestHeaderV3_GetOrderedCrossMiniblocksWithDst(t *testing.T) {
 	t.Parallel()
 

--- a/data/block/block_test.go
+++ b/data/block/block_test.go
@@ -558,6 +558,22 @@ func TestHeader_GetMiniBlockHeadersWithDstShouldWork(t *testing.T) {
 	assert.Equal(t, uint32(0), hashesWithDest2[string(hash2S0R2)])
 }
 
+func TestHeader_GetProposedMiniBlockHeadersWithDst(t *testing.T) {
+	t.Parallel()
+
+	hdr := &block.Header{}
+	require.Empty(t, hdr.GetProposedMiniBlockHeadersWithDst(0))
+
+	hdr.MiniBlockHeaders = []block.MiniBlockHeader{
+		{
+			SenderShardID:   0,
+			ReceiverShardID: 0,
+			Hash:            []byte("hash"),
+		},
+	}
+	require.Empty(t, hdr.GetProposedMiniBlockHeadersWithDst(0))
+}
+
 func TestHeader_GetOrderedCrossMiniblocksWithDstShouldWork(t *testing.T) {
 	t.Parallel()
 

--- a/data/block/metaBlock.go
+++ b/data/block/metaBlock.go
@@ -290,7 +290,7 @@ func (m *MetaBlock) SetShardID(_ uint32) error {
 	return nil
 }
 
-// GetMiniBlockHeadersWithDst as a map of hashes and sender IDs
+// GetMiniBlockHeadersWithDst returns a map of hashes and sender IDs
 func (m *MetaBlock) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32 {
 	if m == nil {
 		return nil
@@ -319,6 +319,15 @@ func (m *MetaBlock) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32 
 	}
 
 	return hashDst
+}
+
+// GetProposedMiniBlockHeadersWithDst returns empty map, as this method just implements the interface needed for supernova
+func (m *MetaBlock) GetProposedMiniBlockHeadersWithDst(_ uint32) map[string]uint32 {
+	if m == nil {
+		return nil
+	}
+
+	return make(map[string]uint32)
 }
 
 // GetOrderedCrossMiniblocksWithDst gets all cross miniblocks with the given destination shard ID, ordered in a

--- a/data/block/metaBlock.go
+++ b/data/block/metaBlock.go
@@ -302,31 +302,15 @@ func (m *MetaBlock) GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32 
 			continue
 		}
 
-		for _, val := range m.ShardInfo[i].ShardMiniBlockHeaders {
-			if val.ReceiverShardID == destId && val.SenderShardID != destId {
-				hashDst[string(val.Hash)] = val.SenderShardID
-			}
-		}
+		addShardMBHeadersMBToDestMap(m.ShardInfo[i].ShardMiniBlockHeaders, hashDst, destId)
 	}
 
-	for _, val := range m.MiniBlockHeaders {
-		isDestinationShard := (val.ReceiverShardID == destId ||
-			val.ReceiverShardID == core.AllShardId) &&
-			val.SenderShardID != destId
-		if isDestinationShard {
-			hashDst[string(val.Hash)] = val.SenderShardID
-		}
-	}
-
+	addMetaMBHeadersMBToDestMap(m.MiniBlockHeaders, hashDst, destId)
 	return hashDst
 }
 
 // GetProposedMiniBlockHeadersWithDst returns empty map, as this method just implements the interface needed for supernova
 func (m *MetaBlock) GetProposedMiniBlockHeadersWithDst(_ uint32) map[string]uint32 {
-	if m == nil {
-		return nil
-	}
-
 	return make(map[string]uint32)
 }
 

--- a/data/block/metaBlockV3.go
+++ b/data/block/metaBlockV3.go
@@ -250,7 +250,7 @@ func (m *MetaBlockV3) GetDeveloperFees() *big.Int {
 	return nil
 }
 
-// GetMiniBlockHeadersWithDst as a map of hashes and sender IDs
+// GetMiniBlockHeadersWithDst returns a map of hashes and sender IDs
 func (m *MetaBlockV3) GetMiniBlockHeadersWithDst(destID uint32) map[string]uint32 {
 	if m == nil {
 		return nil
@@ -262,23 +262,43 @@ func (m *MetaBlockV3) GetMiniBlockHeadersWithDst(destID uint32) map[string]uint3
 			continue
 		}
 
-		for _, val := range m.ShardInfo[i].ShardMiniBlockHeaders {
-			if val.ReceiverShardID == destID && val.SenderShardID != destID {
-				hashDst[string(val.Hash)] = val.SenderShardID
-			}
-		}
+		addShardMBHeadersMBToDestMap(m.ShardInfo[i].ShardMiniBlockHeaders, hashDst, destID)
 	}
 
 	for _, execResults := range m.ExecutionResults {
-		for _, mbHeader := range execResults.MiniBlockHeaders {
-			isDestinationShard := (mbHeader.ReceiverShardID == destID ||
-				mbHeader.ReceiverShardID == core.AllShardId) &&
-				mbHeader.SenderShardID != destID
-			if isDestinationShard {
-				hashDst[string(mbHeader.Hash)] = mbHeader.SenderShardID
-			}
+		addMetaMBHeadersMBToDestMap(execResults.MiniBlockHeaders, hashDst, destID)
+	}
+
+	return hashDst
+}
+
+func addMetaMBHeadersMBToDestMap(miniBlockHeaders []MiniBlockHeader, hashDst map[string]uint32, destID uint32) {
+	for _, mbHeader := range miniBlockHeaders {
+		isDestinationShard := (mbHeader.ReceiverShardID == destID ||
+			mbHeader.ReceiverShardID == core.AllShardId) &&
+			mbHeader.SenderShardID != destID
+		if isDestinationShard {
+			hashDst[string(mbHeader.Hash)] = mbHeader.SenderShardID
 		}
 	}
+}
+
+// GetProposedMiniBlockHeadersWithDst returns a map of hashes and sender IDs for proposed mini blocks
+func (m *MetaBlockV3) GetProposedMiniBlockHeadersWithDst(destID uint32) map[string]uint32 {
+	if m == nil {
+		return nil
+	}
+
+	hashDst := make(map[string]uint32)
+	for i := 0; i < len(m.ShardInfo); i++ {
+		if m.ShardInfo[i].ShardID == destID {
+			continue
+		}
+
+		addShardMBHeadersMBToDestMap(m.ShardInfo[i].ShardMiniBlockHeaders, hashDst, destID)
+	}
+
+	addMetaMBHeadersMBToDestMap(m.MiniBlockHeaders, hashDst, destID)
 
 	return hashDst
 }

--- a/data/block/metaBlockV3.go
+++ b/data/block/metaBlockV3.go
@@ -269,12 +269,14 @@ func (m *MetaBlockV3) GetMiniBlockHeadersWithDst(destID uint32) map[string]uint3
 		}
 	}
 
-	for _, val := range m.MiniBlockHeaders {
-		isDestinationShard := (val.ReceiverShardID == destID ||
-			val.ReceiverShardID == core.AllShardId) &&
-			val.SenderShardID != destID
-		if isDestinationShard {
-			hashDst[string(val.Hash)] = val.SenderShardID
+	for _, execResults := range m.ExecutionResults {
+		for _, mbHeader := range execResults.MiniBlockHeaders {
+			isDestinationShard := (mbHeader.ReceiverShardID == destID ||
+				mbHeader.ReceiverShardID == core.AllShardId) &&
+				mbHeader.SenderShardID != destID
+			if isDestinationShard {
+				hashDst[string(mbHeader.Hash)] = mbHeader.SenderShardID
+			}
 		}
 	}
 

--- a/data/block/metaBlockV3.go
+++ b/data/block/metaBlockV3.go
@@ -290,14 +290,6 @@ func (m *MetaBlockV3) GetProposedMiniBlockHeadersWithDst(destID uint32) map[stri
 	}
 
 	hashDst := make(map[string]uint32)
-	for i := 0; i < len(m.ShardInfo); i++ {
-		if m.ShardInfo[i].ShardID == destID {
-			continue
-		}
-
-		addShardMBHeadersMBToDestMap(m.ShardInfo[i].ShardMiniBlockHeaders, hashDst, destID)
-	}
-
 	addMetaMBHeadersMBToDestMap(m.MiniBlockHeaders, hashDst, destID)
 
 	return hashDst

--- a/data/block/metaBlockV3_test.go
+++ b/data/block/metaBlockV3_test.go
@@ -334,6 +334,46 @@ func TestMetaBlockV3_GetMiniBlockHeadersWithDst(t *testing.T) {
 	})
 }
 
+func TestMetaBlockV3_GetProposedMiniBlockHeadersWithDst(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil receiver", func(t *testing.T) {
+		t.Parallel()
+		var mb2 *block.MetaBlockV3
+		require.Nil(t, mb2.GetProposedMiniBlockHeadersWithDst(0))
+	})
+	t.Run("should return headers with correct destination", func(t *testing.T) {
+		t.Parallel()
+
+		metaHdr := &block.MetaBlockV3{Round: 15}
+		metaHdr.ShardInfo = make([]block.ShardData, 0)
+
+		shardMBHeader := make([]block.MiniBlockHeader, 0)
+		shMBHdr1 := block.MiniBlockHeader{SenderShardID: 0, ReceiverShardID: 1, Hash: []byte("hash1")}
+		shMBHdr2 := block.MiniBlockHeader{SenderShardID: 0, ReceiverShardID: 1, Hash: []byte("hash2")}
+		shardMBHeader = append(shardMBHeader, shMBHdr1, shMBHdr2)
+
+		shData1 := block.ShardData{ShardID: 0, HeaderHash: []byte("sh"), ShardMiniBlockHeaders: shardMBHeader}
+		metaHdr.ShardInfo = append(metaHdr.ShardInfo, shData1)
+
+		shData2 := block.ShardData{ShardID: 1, HeaderHash: []byte("sh"), ShardMiniBlockHeaders: shardMBHeader}
+		metaHdr.ShardInfo = append(metaHdr.ShardInfo, shData2)
+
+		mbsFromMetaToShard0 := []block.MiniBlockHeader{{Hash: []byte("hash3"), SenderShardID: core.MetachainShardId, ReceiverShardID: 0}}
+		mbsFromMetaToShard1 := []block.MiniBlockHeader{{Hash: []byte("hash4"), SenderShardID: core.MetachainShardId, ReceiverShardID: 1}}
+		metaHdr.MiniBlockHeaders = append(metaHdr.MiniBlockHeaders, mbsFromMetaToShard0...)
+		metaHdr.MiniBlockHeaders = append(metaHdr.MiniBlockHeaders, mbsFromMetaToShard1...)
+		// should not include execution results
+		metaHdr.ExecutionResults = make([]*block.MetaExecutionResult, 1)
+		metaHdr.ExecutionResults[0] = &block.MetaExecutionResult{MiniBlockHeaders: mbsFromMetaToShard1}
+
+		mbDst0 := metaHdr.GetProposedMiniBlockHeadersWithDst(0)
+		require.Equal(t, len(mbsFromMetaToShard0), len(mbDst0))
+		mbDst1 := metaHdr.GetProposedMiniBlockHeadersWithDst(1)
+		require.Equal(t, len(shardMBHeader)+len(mbsFromMetaToShard1), len(mbDst1))
+	})
+}
+
 func TestMetaBlockV3_GetOrderedCrossMiniblocksWithDst(t *testing.T) {
 	t.Parallel()
 

--- a/data/block/metaBlockV3_test.go
+++ b/data/block/metaBlockV3_test.go
@@ -370,7 +370,7 @@ func TestMetaBlockV3_GetProposedMiniBlockHeadersWithDst(t *testing.T) {
 		mbDst0 := metaHdr.GetProposedMiniBlockHeadersWithDst(0)
 		require.Equal(t, len(mbsFromMetaToShard0), len(mbDst0))
 		mbDst1 := metaHdr.GetProposedMiniBlockHeadersWithDst(1)
-		require.Equal(t, len(shardMBHeader)+len(mbsFromMetaToShard1), len(mbDst1))
+		require.Equal(t, len(mbsFromMetaToShard1), len(mbDst1)) // should not include shard info data
 	})
 }
 

--- a/data/block/metaBlockV3_test.go
+++ b/data/block/metaBlockV3_test.go
@@ -323,8 +323,9 @@ func TestMetaBlockV3_GetMiniBlockHeadersWithDst(t *testing.T) {
 
 		mbsFromMetaToShard0 := []block.MiniBlockHeader{{Hash: []byte("hash3"), SenderShardID: core.MetachainShardId, ReceiverShardID: 0}}
 		mbsFromMetaToShard1 := []block.MiniBlockHeader{{Hash: []byte("hash4"), SenderShardID: core.MetachainShardId, ReceiverShardID: 1}}
-		metaHdr.MiniBlockHeaders = append(metaHdr.MiniBlockHeaders, mbsFromMetaToShard0...)
-		metaHdr.MiniBlockHeaders = append(metaHdr.MiniBlockHeaders, mbsFromMetaToShard1...)
+		metaHdr.ExecutionResults = make([]*block.MetaExecutionResult, 2)
+		metaHdr.ExecutionResults[0] = &block.MetaExecutionResult{MiniBlockHeaders: mbsFromMetaToShard0}
+		metaHdr.ExecutionResults[1] = &block.MetaExecutionResult{MiniBlockHeaders: mbsFromMetaToShard1}
 
 		mbDst0 := metaHdr.GetMiniBlockHeadersWithDst(0)
 		assert.Equal(t, len(mbsFromMetaToShard0), len(mbDst0))

--- a/data/block/metaBlock_test.go
+++ b/data/block/metaBlock_test.go
@@ -361,6 +361,22 @@ func TestMetaBlock_GetOrderedCrossMiniblocksWithDstShouldWork(t *testing.T) {
 	assert.Equal(t, miniBlocksInfo[2].Round, uint64(7))
 }
 
+func TestMetaBlock_GetProposedMiniBlockHeadersWithDst(t *testing.T) {
+	t.Parallel()
+
+	hdr := &block.MetaBlock{}
+	require.Empty(t, hdr.GetProposedMiniBlockHeadersWithDst(0))
+
+	hdr.MiniBlockHeaders = []block.MiniBlockHeader{
+		{
+			SenderShardID:   0,
+			ReceiverShardID: 0,
+			Hash:            []byte("hash"),
+		},
+	}
+	require.Empty(t, hdr.GetProposedMiniBlockHeadersWithDst(0))
+}
+
 func TestMetaBlock_SetScheduledRootHash(t *testing.T) {
 	t.Parallel()
 

--- a/data/interface.go
+++ b/data/interface.go
@@ -51,6 +51,7 @@ type HeaderHandler interface {
 	GetDeveloperFees() *big.Int
 	GetReserved() []byte
 	GetMiniBlockHeadersWithDst(destId uint32) map[string]uint32
+	GetProposedMiniBlockHeadersWithDst(destId uint32) map[string]uint32
 	GetOrderedCrossMiniblocksWithDst(destId uint32) []*MiniBlockInfo
 	GetMiniBlockHeadersHashes() [][]byte
 	GetMiniBlockHeaderHandlers() []MiniBlockHeaderHandler


### PR DESCRIPTION
- `GetMiniBlockHeadersWithDst` whould return finalized/executed data for meta block/ shard block v3
- Added `GetProposedMiniBlockHeadersWithDst` to return proposed data (as it was previously implemented)